### PR TITLE
solution 04-file-server-post

### DIFF
--- a/03-streams/03-file-server-get/server.js
+++ b/03-streams/03-file-server-get/server.js
@@ -10,7 +10,7 @@ server.on('request', (req, res) => {
   const pathname = url.pathname.slice(1);
 
   const filepath = path.join(__dirname, 'files', pathname);
-console.log(pathname);
+
   if(pathname.includes('/')){
     res.statusCode = 400;
     res.end('nested path are not allowed');
@@ -33,7 +33,7 @@ console.log(pathname);
         }
       });
 
-      req.on('aborted', _ => req.destroy());
+      req.on('aborted', _ => reader.destroy());
       break;
 
     default:

--- a/03-streams/04-file-server-post/server.js
+++ b/03-streams/04-file-server-post/server.js
@@ -1,6 +1,8 @@
 const url = require('url');
 const http = require('http');
 const path = require('path');
+const fs = require('fs');
+const LimitSizeStream = require('./LimitSizeStream');
 
 const server = new http.Server();
 
@@ -10,10 +12,51 @@ server.on('request', (req, res) => {
 
   const filepath = path.join(__dirname, 'files', pathname);
 
+  if(pathname.includes('/')){
+    res.statusCode = 400;
+    res.end('nested path are not allowed');
+    return;
+  }
+
   switch (req.method) {
     case 'POST':
+      const writer = fs.createWriteStream(filepath, {flags: 'wx'});
+      const limiter = new LimitSizeStream({limit: 1e6});
 
-      break;
+      req
+      .on('aborted', () => {
+        writer.destroy();
+        limiter.destroy();
+        fs.unlink(filepath, _ => {});
+      })
+      .pipe(limiter)
+      .on('error', error => {
+          if(error.code === 'LIMIT_EXCEEDED'){
+            res.statusCode = 413;
+            res.end('file is big');
+          } else {
+            res.statusCode = 500;
+            res.end('internal error');
+          }
+
+          writer.destroy();
+          fs.unlink(filepath, _ => {});
+      })
+      .pipe(writer)
+      .on('error', error => {
+          if(error.code === 'EEXIST'){
+            res.statusCode = 409;
+            res.end('file already exist');
+          } else {
+            res.statusCode = 500;
+            res.end('internal error');
+          }
+      })
+      .on('finish', () => {
+          res.statusCode = 201;
+          res.end('file written successfully');
+      });
+    break;
 
     default:
       res.statusCode = 501;

--- a/04-testing-configuration-logging/01-unit-tests/test/Validator.test.js
+++ b/04-testing-configuration-logging/01-unit-tests/test/Validator.test.js
@@ -23,7 +23,7 @@ describe('testing-configuration-logging/unit-tests', () => {
       expect(errors[0]).to.have.property('error').and.to.be.equal('too short, expect 10, got 6');
     });
 
-    it('валидатор проверяет чиловые поля', () => {
+    it('валидатор проверяет нижний порог числовых полей', () => {
 
       const validator = new Validator({
         age: {
@@ -40,7 +40,7 @@ describe('testing-configuration-logging/unit-tests', () => {
       expect(errors[0]).to.have.property('error').and.to.be.equal('too small, expect 18, got 5');
     });
 
-    it('валидатор проверяет чиловые поля', () => {
+    it('валидатор проверяет верхний порог числовых полей', () => {
 
       const validator = new Validator({
         age: {


### PR DESCRIPTION
В этом решении 4-ой задачи есть один не очень хороший момент.
Если доступный лимит файла будет меньше записываемого чанка, к примеру лимит 10 байт, а чанк - 64 килобайта, то сработает ошибка превышения размера передаваемых данных, выброшенная объектом LimitSizeStream. Стрим для записи будет задестроен и файл будет уничтожен. Проверка проверка на наличие файла  не будет выполнена. Таким образом, можно затереть существующий файл.
Красивое решение этого бага пока не могу придумать. И скорее всего тот же эффект будет если соединение будет установлено и тут же разорвано.